### PR TITLE
[codex] Add DocType design skill

### DIFF
--- a/.cursor/commands/frappe-doctype-design.md
+++ b/.cursor/commands/frappe-doctype-design.md
@@ -1,0 +1,10 @@
+# Frappe DocType Design
+
+Handle this as Frappe DocType design work.
+
+- Design the DocType as a human-facing form, not a flat field dump.
+- Add only fields required by the actual use case.
+- Use tabs, section breaks, and column breaks when they match the user's workflow.
+- Group fields by mental model: overview, core details, people or links, schedule, finance, settings, and activity or audit when relevant.
+- Keep primary required fields first and advanced or rare fields later.
+- Avoid empty sections, vanity fields, duplicate fields, and speculative future fields.

--- a/.cursor/rules/frappe-agent.mdc
+++ b/.cursor/rules/frappe-agent.mdc
@@ -8,4 +8,5 @@ alwaysApply: false
 - Prefer Frappe-native ORM and Query Builder patterns before raw SQL.
 - When reviewing raw SQL, check `tab{DocType}` naming, permissions, and transaction boundaries.
 - Distinguish desk-native, `www`, Vue/`frappe-ui`, React, and external SPA frontend paths.
+- When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat custom-remoted or forked apps as custom-derived apps and avoid invasive upstream patching when a custom app can own the change.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,4 +8,5 @@ Treat this repository as Frappe and ERPNext-specific guidance for coding agents.
 - Prefer Frappe-native database access layers (`frappe.db`, Query Builder) over raw SQL when possible.
 - When raw SQL is required, use correct `tab{DocType}` naming and call out permission and transaction implications.
 - Separate frontend guidance into desk-native pages, `www`, Vue/`frappe-ui`, React, and external SPA patterns.
+- When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat non-official app remotes as custom or custom-derived.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Use this repository when the task touches Frappe Framework, ERPNext, Bench, or F
 - Prefer Frappe-native APIs and ORM patterns before raw SQL.
 - Treat raw SQL and `get_all` as deliberate choices that need explanation.
 - Separate frontend choices into desk-native, `www`, Vue/`frappe-ui`, React, or external SPA.
+- When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 
 ## Bench Guidance
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,4 +10,5 @@ When working in a Frappe or ERPNext codebase:
 - Use Frappe-native ORM or Query Builder when possible.
 - If raw SQL is necessary, use correct `tab{DocType}` naming and explain permission implications.
 - Distinguish desk-native Vue and `frappe-ui` patterns from React or external SPA work.
+- When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat forked or custom-remote apps as custom-derived apps and be careful with upstream patching.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Bench-aware inspection before app installs, migrations, or environment changes
 - Frappe-native SQL and ORM guidance
 - Customization-layer routing for `Custom Field`, `Property Setter`, `Client Script`, `Server Script`, `Workspace`, `Web Page`, `Report`, `Dashboard`, and related surfaces
+- DocType form UX guidance for useful fields, tabs, sections, columns, and required-field discipline
 - ERPNext-aware guidance for deciding between configuration, metadata, workflow, and code changes
 - Frontend guidance for Vue, React, `frappe-ui`, desk pages, `www`, and external SPA patterns
 
@@ -19,6 +20,7 @@
 - `frappe-bench`
 - `frappe-sql`
 - `frappe-customization`
+- `frappe-doctype-design`
 - `frappe-search`
 - `frappe-erpnext`
 
@@ -188,6 +190,10 @@ Use Frappe Agent to choose the right Frappe customization layer for adding field
 ```
 
 ```text
+Use Frappe Agent to design a clean DocType layout for a service request workflow.
+```
+
+```text
 Use Frappe Agent to review whether this Frappe SQL should use frappe.db, frappe.qb, or raw SQL.
 ```
 
@@ -207,6 +213,7 @@ frappe-agent/
 │   │   ├── frappe-backend.md
 │   │   ├── frappe-bench.md
 │   │   ├── frappe-customization.md
+│   │   ├── frappe-doctype-design.md
 │   │   ├── frappe-erpnext.md
 │   │   ├── frappe-frontend.md
 │   │   ├── frappe-fullstack.md
@@ -227,6 +234,7 @@ frappe-agent/
 │   ├── frappe-backend.md
 │   ├── frappe-bench.md
 │   ├── frappe-customization.md
+│   ├── frappe-doctype-design.md
 │   ├── frappe-erpnext.md
 │   ├── frappe-frontend.md
 │   ├── frappe-fullstack.md
@@ -236,6 +244,7 @@ frappe-agent/
 │   ├── frappe-backend/
 │   ├── frappe-bench/
 │   ├── frappe-customization/
+│   ├── frappe-doctype-design/
 │   ├── frappe-erpnext/
 │   ├── frappe-frontend/
 │   ├── frappe-fullstack/

--- a/commands/frappe-doctype-design.md
+++ b/commands/frappe-doctype-design.md
@@ -1,0 +1,10 @@
+# Frappe DocType Design
+
+Handle this as Frappe DocType design work.
+
+- Design the DocType as a human-facing form, not a flat field dump.
+- Add only fields required by the actual use case.
+- Use tabs, section breaks, and column breaks when they match the user's workflow.
+- Group fields by mental model: overview, core details, people or links, schedule, finance, settings, and activity or audit when relevant.
+- Keep primary required fields first and advanced or rare fields later.
+- Avoid empty sections, vanity fields, duplicate fields, and speculative future fields.

--- a/skills/frappe-customization/SKILL.md
+++ b/skills/frappe-customization/SKILL.md
@@ -38,3 +38,4 @@ Preferred decision ladder:
 
 Explicitly call out when a request should use `Custom Field` rather than editing a DocType JSON file directly.
 
+When creating or redesigning a DocType, also apply `frappe-doctype-design` so fields, tabs, sections, columns, and required flags are chosen for a clean human workflow instead of a flat field dump.

--- a/skills/frappe-doctype-design/SKILL.md
+++ b/skills/frappe-doctype-design/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: frappe-doctype-design
+description: Frappe DocType creation and form UX guidance. Use when creating, reviewing, or redesigning DocTypes, including field choice, tabs, sections, columns, required fields, naming, child tables, and form usability.
+---
+
+Design every DocType as a human-facing form, not a flat database table.
+
+Before adding fields, identify:
+- the DocType's purpose and primary user
+- the real business process or lifecycle it supports
+- the relationships, status, reporting, and search needs
+- whether it is master data, a transaction, a child table, or a configuration DocType
+
+Field discipline:
+- Add only fields that are required for identity, workflow, relationships, decisions, audit, reporting, or search.
+- Do not add speculative, vanity, duplicate, or generic fields unless the use case clearly needs them.
+- Make required fields truly required, not merely convenient.
+- Use child tables only for real one-to-many repeating data.
+- Prefer human-readable labels and stable snake_case fieldnames.
+
+Form layout:
+- Do not dump all fields into one tab or one section.
+- Use `Tab Break` for major mental models only when the form has enough fields to justify tabs.
+- Use `Section Break` for logical groups inside a tab.
+- Use `Column Break` to create balanced, scan-friendly rows.
+- Put the title, status, primary links, and most common required inputs first.
+- Put advanced, rare, admin, or integration fields later, and fold them when appropriate.
+- Avoid empty tabs, thin sections, and layout breaks that exist only for decoration.
+
+Useful tab patterns include:
+- Overview for identity, status, and primary summary fields
+- Details for the main business data
+- People or Parties for owners, customers, suppliers, employees, or contacts
+- Schedule for dates, timelines, reminders, or recurrence
+- Finance for amounts, accounts, taxes, or pricing
+- Settings for infrequent configuration
+- Activity or Audit for comments, references, or system-facing traceability
+
+When proposing or creating a DocType, present the layout grouped by tab and section, and explain why each group exists. If a requested field does not belong, call it out and omit it unless the user confirms the need.

--- a/skills/frappe-fullstack/SKILL.md
+++ b/skills/frappe-fullstack/SKILL.md
@@ -24,6 +24,7 @@ When relevant, route into these companion skills:
 - `frappe-bench`
 - `frappe-sql`
 - `frappe-customization`
+- `frappe-doctype-design`
 - `frappe-search`
 - `frappe-erpnext`
 
@@ -31,4 +32,3 @@ Be opinionated about:
 - not restarting an already running bench
 - not patching upstream-derived apps when a custom app can own the change
 - not using raw SQL when a Frappe-native path is better
-


### PR DESCRIPTION
## Summary

- add a new `frappe-doctype-design` skill for clean DocType form UX
- add matching Claude/Cursor command shims
- wire DocType design guidance into shared agent, Cursor, Copilot, Claude, fullstack, customization, and README docs
- add a GitHub Actions release workflow that publishes versioned plugin archives and checksums from `v*` tags or manual workflow dispatch

## Validation

- `python3 -m json.tool` on Codex, Claude, and marketplace JSON manifests
- `git diff --check`
- parsed `.github/workflows/release.yml` as YAML locally
- locally dry-ran release packaging for `0.1.0` and produced `.zip`, `.tar.gz`, and `.sha256` assets
