### PR TITLE
[codex] Add GitHub release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,135 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version without the v prefix, for example 0.1.0"
+        required: true
+        default: "0.1.0"
+      prerelease:
+        description: "Mark this GitHub Release as a prerelease"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build release assets
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            tag="${GITHUB_REF_NAME}"
+            version="${tag#v}"
+          else
+            version="${{ inputs.version }}"
+            tag="v${version}"
+          fi
+
+          if [[ ! "${version}" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid version: ${version}" >&2
+            exit 1
+          fi
+
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Validate manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 -m json.tool .codex-plugin/plugin.json >/dev/null
+          python3 -m json.tool .agents/plugins/marketplace.json >/dev/null
+          python3 -m json.tool .claude-plugin/plugin.json >/dev/null
+          python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
+
+      - name: Package plugin
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          version="${{ steps.version.outputs.version }}"
+          package_root="dist/package/frappe-agent"
+
+          rm -rf dist
+          mkdir -p "${package_root}"
+
+          rsync -a \
+            --exclude ".git/" \
+            --exclude ".claude/settings.local.json" \
+            --exclude ".github/workflows/" \
+            --exclude "dist/" \
+            --exclude "build/" \
+            ./ "${package_root}/"
+
+          (
+            cd dist/package
+            zip -r "../frappe-agent-${version}.zip" frappe-agent
+            tar -czf "../frappe-agent-${version}.tar.gz" frappe-agent
+          )
+
+          (
+            cd dist
+            sha256sum "frappe-agent-${version}.zip" "frappe-agent-${version}.tar.gz" > "frappe-agent-${version}.sha256"
+          )
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.prerelease || false }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          notes_file="$(mktemp)"
+          {
+            printf 'Frappe Agent %s\n\n' "${TAG_NAME}"
+            printf 'Release assets:\n'
+            printf -- '- frappe-agent-%s.zip\n' "${VERSION}"
+            printf -- '- frappe-agent-%s.tar.gz\n' "${VERSION}"
+            printf -- '- frappe-agent-%s.sha256\n\n' "${VERSION}"
+            printf 'Install by downloading an archive, extracting it, and adding the extracted repository as a local Codex or Claude plugin marketplace.\n'
+          } > "${notes_file}"
+
+          prerelease_flag=()
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            prerelease_flag=(--prerelease)
+          fi
+
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            gh release upload "${TAG_NAME}" \
+              "dist/frappe-agent-${VERSION}.zip" \
+              "dist/frappe-agent-${VERSION}.tar.gz" \
+              "dist/frappe-agent-${VERSION}.sha256" \
+              --clobber
+          else
+            gh release create "${TAG_NAME}" \
+              "dist/frappe-agent-${VERSION}.zip" \
+              "dist/frappe-agent-${VERSION}.tar.gz" \
+              "dist/frappe-agent-${VERSION}.sha256" \
+              --target "${GITHUB_SHA}" \
+              --title "Frappe Agent ${TAG_NAME}" \
+              --notes-file "${notes_file}" \
+              "${prerelease_flag[@]}"
+          fi

--- a/README.md
+++ b/README.md
@@ -177,6 +177,25 @@ ln -s /path/to/frappe-agent/AGENTS.md /path/to/your-frappe-project/AGENTS.md
 
 Copilot does not use the same plugin marketplace flow here, so the practical local installation path is repository instructions.
 
+## Releases
+
+GitHub Releases are built by `.github/workflows/release.yml`.
+
+Create a release from a tag:
+
+```bash
+git tag v0.1.0
+git push upstream v0.1.0
+```
+
+Or run the `Release` workflow manually from GitHub Actions and provide a version such as `0.1.0`.
+
+Each release uploads:
+
+- `frappe-agent-{version}.zip`
+- `frappe-agent-{version}.tar.gz`
+- `frappe-agent-{version}.sha256`
+
 ## Usage Examples
 
 Ask Codex to use the plugin naturally in the prompt:
@@ -227,7 +246,9 @@ frappe-agent/
 ├── .codex-plugin/
 │   └── plugin.json
 ├── .github/
-│   └── copilot-instructions.md
+│   ├── copilot-instructions.md
+│   └── workflows/
+│       └── release.yml
 ├── AGENTS.md
 ├── CLAUDE.md
 ├── commands/


### PR DESCRIPTION
## Summary

- add a GitHub Actions release workflow for Frappe Agent
- support releases from `v*` tags and manual workflow dispatch with a version number
- package the plugin as `.zip` and `.tar.gz` release assets with a `.sha256` checksum file
- document the release process in the README

## Validation

- parsed `.github/workflows/release.yml` as YAML locally
- `python3 -m json.tool` on Codex, Claude, and marketplace JSON manifests
- `git diff --check upstream/main...HEAD`
- locally dry-ran package generation for `0.1.0` and produced `.zip`, `.tar.gz`, and `.sha256` assets
