### PR TITLE
Fix release version validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
             tag="v${version}"
           fi
 
-          if [[ ! "${version}" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
             echo "Invalid version: ${version}" >&2
             exit 1
           fi


### PR DESCRIPTION
## Summary

- fix release workflow semantic version validation for tag releases like `v0.1.0`

## Validation

- parsed workflow YAML locally
- verified Bash regex accepts `0.1.0`
- JSON manifests parsed with `python3 -m json.tool`
- `git diff --check`
