### PR TITLE
Improve plugin trust signals

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,6 +7,7 @@
     {
       "name": "frappe-agent",
       "source": {
+        "source": "local",
         "path": "./"
       },
       "policy": {

--- a/.codexignore
+++ b/.codexignore
@@ -1,0 +1,14 @@
+.git/
+.claude/settings.local.json
+.env
+.env.*
+dist/
+build/
+node_modules/
+__pycache__/
+.pytest_cache/
+.mypy_cache/
+*.pyc
+*.pyo
+*.pyd
+.DS_Store

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/plugin-scan.yml
+++ b/.github/workflows/plugin-scan.yml
@@ -1,0 +1,35 @@
+name: Plugin Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  security-events: write
+
+jobs:
+  scan:
+    name: HOL plugin quality gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Scan plugin
+        id: scan
+        uses: hashgraph-online/ai-plugin-scanner-action@d54b5d50c5c11c069aca137f71a75d5582d776b6
+        with:
+          plugin_dir: "."
+          format: "sarif"
+          output: "ai-plugin-scanner.sarif"
+          profile: "public-marketplace"
+          min_score: "80"
+          fail_on_severity: "high"
+          upload_sarif: "true"
+          registry_payload_output: "ai-plugin-registry-payload.json"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 0
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Frappe Agent for Codex
 
+[![HOL Trust Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dtrust%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
+[![HOL Security](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dsecurity%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
+[![Release](https://img.shields.io/github/v/release/Dkm0315/frappe-agent)](https://github.com/Dkm0315/frappe-agent/releases)
+[![License](https://img.shields.io/github/license/Dkm0315/frappe-agent)](./LICENSE)
+
 `frappe-agent` is a Codex plugin for Frappe Framework and ERPNext development. It makes Codex more aware of Frappe-specific patterns so it can inspect benches more safely, choose the right customization layer, and avoid generic framework mistakes.
 
 ## What It Covers

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| `main` | Yes |
+| Latest published release | Yes |
+
+## Reporting a Vulnerability
+
+Please do not disclose security issues publicly before they have been reviewed.
+
+To report a vulnerability, open a private report through GitHub Security Advisories for this repository, or email `dhairya15marwaha@gmail.com` with:
+
+- a short description of the issue
+- affected files, skills, commands, or plugin metadata
+- reproduction steps or proof of concept details
+- expected impact
+- suggested fixes, if you already have them
+
+We aim to acknowledge reports within 72 hours and follow up with an initial assessment as soon as practical.
+
+## Security Practices
+
+- Keep credentials, site tokens, bench secrets, and ERPNext/Frappe environment values out of plugin files.
+- Review changes to skills and commands for prompt-injection risks before release.
+- Run the plugin scanner workflow before publishing release artifacts.
+- Prefer the latest published release when installing this plugin in day-to-day projects.


### PR DESCRIPTION
## Summary
- add a security policy, `.codexignore`, Dependabot config, and HOL plugin scanner workflow
- pin the release workflow checkout action by commit SHA
- add HOL trust/security, release, and license badges to the README
- normalize the local marketplace source shape for scanner compatibility

## Why
These changes improve the repository signals that HOL uses for marketplace trust and security scoring, while keeping the plugin install and release flow intact.

## Validation
- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `python3 -m json.tool .claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- `pipx run --spec 'plugin-scanner' plugin-scanner scan . --format text` reported `Final Score: 98/100` and trust `80.39/100`
