### PR TITLE
Add Frappe ecosystem skills and SEO updates

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "email": "dhairya15marwaha@gmail.com"
   },
   "metadata": {
-    "description": "Frappe and ERPNext development tools for Claude Code.",
+    "description": "Frappe, ERPNext, and Frappe ecosystem development tools for Claude Code.",
     "version": "0.1.0"
   },
   "plugins": [
     {
       "name": "frappe-agent",
       "source": "./",
-      "description": "Frappe and ERPNext coding, customization, bench, and review intelligence.",
+      "description": "Frappe, ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, and Payments coding guidance.",
       "version": "0.1.0"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frappe-agent",
   "version": "0.1.0",
-  "description": "Frappe and ERPNext coding, customization, bench, and review intelligence for Claude Code.",
+  "description": "Frappe, ERPNext, and Frappe ecosystem coding, customization, bench, and review intelligence for Claude Code and AI coding workflows.",
   "author": {
     "name": "Dhairya Marwaha",
     "email": "dhairya15marwaha@gmail.com",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "frappe-agent",
   "version": "0.1.0",
-  "description": "Frappe and ERPNext coding, customization, bench, and review intelligence for Codex.",
+  "description": "Frappe, ERPNext, and Frappe ecosystem coding, customization, bench, and review intelligence for AI coding assistants.",
   "author": {
     "name": "Dhairya Marwaha",
     "email": "dhairya15marwaha@gmail.com",
@@ -14,6 +14,14 @@
     "frappe",
     "erpnext",
     "bench",
+    "helpdesk",
+    "crm",
+    "lms",
+    "hrms",
+    "drive",
+    "gameplan",
+    "insights",
+    "payments",
     "python",
     "javascript",
     "react",
@@ -23,8 +31,8 @@
   "interface": {
     "displayName": "Frappe Agent",
     "composerIcon": "./assets/frappe-agent-icon.svg",
-    "shortDescription": "Frappe-aware coding, bench, SQL, and customization help.",
-    "longDescription": "Adds Frappe and ERPNext-specific skills for full-stack work, bench operations, SQL and ORM decisions, admin customizations, and workflow-aware code review.",
+    "shortDescription": "Frappe, ERPNext, and ecosystem app help.",
+    "longDescription": "Adds Frappe, ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, and Payments skills for full-stack work, bench operations, SQL and ORM decisions, admin customizations, DocType design, and workflow-aware code review.",
     "developerName": "Dhairya Marwaha",
     "category": "Developer Tools",
     "capabilities": [
@@ -37,8 +45,8 @@
     "termsOfServiceURL": "https://github.com/Dkm0315/frappe-agent",
     "defaultPrompt": [
       "Use Frappe Agent to inspect this bench before changing anything.",
-      "Use Frappe Agent to choose the right Frappe customization layer.",
-      "Use Frappe Agent to review this Frappe SQL or ORM code."
+      "Use Frappe Agent to choose the right Frappe or ERPNext customization layer.",
+      "Use Frappe Agent to design a Helpdesk, CRM, LMS, Drive, or ERPNext workflow."
     ],
     "brandColor": "#1F7A5A"
   }

--- a/.cursor/commands/frappe-builder.md
+++ b/.cursor/commands/frappe-builder.md
@@ -1,0 +1,7 @@
+# Frappe Builder
+
+Treat the task as Frappe Builder or website work.
+
+- Identify page purpose, audience, conversion goal, content owner, forms, routing, SEO, analytics, and publishing needs.
+- Prefer Builder pages, blocks, web forms, website settings, redirects, scripts, styles, and metadata before custom frontend code.
+- Include clear title, description, readable headings, internal links, and useful content.

--- a/.cursor/commands/frappe-crm.md
+++ b/.cursor/commands/frappe-crm.md
@@ -1,0 +1,7 @@
+# Frappe CRM
+
+Treat the task as Frappe CRM work.
+
+- Identify leads, deals, contacts, organizations, activities, pipelines, and ownership rules.
+- Prefer pipeline configuration, custom fields, workflows, notifications, reports, dashboards, and workspaces before code.
+- Be deliberate about integration with ERPNext Selling records.

--- a/.cursor/commands/frappe-drive.md
+++ b/.cursor/commands/frappe-drive.md
@@ -1,0 +1,7 @@
+# Frappe Drive
+
+Treat the task as Frappe Drive work.
+
+- Identify file/folder ownership, sharing, visibility, storage, previews, indexing, retention, and linked records.
+- Preserve file permission checks and avoid exposing private paths or signed URLs too broadly.
+- Keep file metadata, sharing state, linked record, recent activity, and primary actions visible.

--- a/.cursor/commands/frappe-gameplan.md
+++ b/.cursor/commands/frappe-gameplan.md
@@ -1,0 +1,7 @@
+# Frappe Gameplan
+
+Treat the task as Frappe Gameplan work.
+
+- Identify projects, tasks, discussions, decisions, notes, milestones, teams, and visibility rules.
+- Preserve async collaboration history and decision trails.
+- Make ownership, due dates, blockers, recent decisions, and pending activity easy to scan.

--- a/.cursor/commands/frappe-helpdesk.md
+++ b/.cursor/commands/frappe-helpdesk.md
@@ -1,0 +1,7 @@
+# Frappe Helpdesk
+
+Treat the task as Frappe Helpdesk work.
+
+- Identify ticket lifecycle, channels, SLA, priority, escalation, assignment, and portal needs.
+- Prefer settings, custom fields, workflows, notifications, reports, dashboards, and portal configuration before app code.
+- Preserve customer, agent, team, and guest permission boundaries.

--- a/.cursor/commands/frappe-hrms.md
+++ b/.cursor/commands/frappe-hrms.md
@@ -1,0 +1,7 @@
+# Frappe HRMS
+
+Treat the task as Frappe HRMS work.
+
+- Identify attendance, leave, payroll, shifts, claims, recruitment, onboarding, appraisals, and HR reports.
+- Protect salary, personal, attendance, and performance data.
+- Call out jurisdiction-specific payroll assumptions.

--- a/.cursor/commands/frappe-insights.md
+++ b/.cursor/commands/frappe-insights.md
@@ -1,0 +1,7 @@
+# Frappe Insights
+
+Treat the task as Frappe Insights and analytics work.
+
+- Define the business question, metric grain, filters, audience, freshness, and permissions.
+- Choose between Frappe Insights, ERPNext reports, Query Reports, Script Reports, Dashboards, and Workspaces.
+- Define numerator, denominator, date basis, status filters, units, and exclusions.

--- a/.cursor/commands/frappe-lms.md
+++ b/.cursor/commands/frappe-lms.md
@@ -1,0 +1,7 @@
+# Frappe LMS
+
+Treat the task as Frappe LMS work.
+
+- Identify learner, instructor, evaluator, and admin roles.
+- Separate course, batch, lesson, quiz, assignment, assessment, enrollment, progress, and certificate concerns.
+- Protect learner data, grading, enrollment, and assessment permissions.

--- a/.cursor/commands/frappe-payments.md
+++ b/.cursor/commands/frappe-payments.md
@@ -1,0 +1,7 @@
+# Frappe Payments
+
+Treat the task as Frappe Payments or ERPNext payment workflow work.
+
+- Identify gateway, currency, customer, invoice/order, subscription, settlement, refund, and reconciliation flows.
+- Never hardcode gateway secrets or expose credentials in client code.
+- Make webhook handlers idempotent and verify signatures where supported.

--- a/.cursor/rules/frappe-agent.mdc
+++ b/.cursor/rules/frappe-agent.mdc
@@ -1,5 +1,5 @@
 ---
-description: Frappe and ERPNext repository guidance
+description: Frappe, ERPNext, and Frappe ecosystem repository guidance
 alwaysApply: false
 ---
 
@@ -10,3 +10,4 @@ alwaysApply: false
 - Distinguish desk-native, `www`, Vue/`frappe-ui`, React, and external SPA frontend paths.
 - When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat custom-remoted or forked apps as custom-derived apps and avoid invasive upstream patching when a custom app can own the change.
+- Route app-specific work through the right ecosystem model: ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, or Payments.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Frappe Agent Copilot Instructions
 
-Treat this repository as Frappe and ERPNext-specific guidance for coding agents.
+Treat this repository as Frappe, ERPNext, and Frappe ecosystem guidance for coding agents.
 
 - Inspect bench and site context before changing code or suggesting commands.
 - Prefer the correct Frappe customization surface before writing framework code.
@@ -10,3 +10,5 @@ Treat this repository as Frappe and ERPNext-specific guidance for coding agents.
 - Separate frontend guidance into desk-native pages, `www`, Vue/`frappe-ui`, React, and external SPA patterns.
 - When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat non-official app remotes as custom or custom-derived.
+- Route app-specific work through the right ecosystem model: ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, or Payments.
+- Protect sensitive app data: customer tickets, CRM pipelines, learner records, private files, salary/payroll data, payment secrets, and analytics permissions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Frappe Agent Instructions
 
-Use this repository when the task touches Frappe Framework, ERPNext, Bench, or Frappe-adjacent frontend work.
+Use this repository when the task touches Frappe Framework, ERPNext, Bench, or Frappe ecosystem apps such as Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, or Payments.
 
 ## Core Behavior
 
@@ -11,6 +11,7 @@ Use this repository when the task touches Frappe Framework, ERPNext, Bench, or F
 - Treat raw SQL and `get_all` as deliberate choices that need explanation.
 - Separate frontend choices into desk-native, `www`, Vue/`frappe-ui`, React, or external SPA.
 - When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
+- Route app-specific work through the matching ecosystem model: ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, or Payments.
 
 ## Bench Guidance
 
@@ -27,3 +28,15 @@ Use this repository when the task touches Frappe Framework, ERPNext, Bench, or F
 
 - First determine whether a request belongs in configuration, workflow, metadata, reporting, dashboards, workspace setup, or code.
 - Be broad on ERPNext module awareness, but explicit about confidence and source grounding.
+
+## Ecosystem App Guidance
+
+- For Helpdesk, prioritize ticket lifecycle, SLA, assignment, portal, and support reporting.
+- For CRM, separate leads, deals, contacts, organizations, activities, and ERPNext Selling handoff.
+- For LMS, protect enrollment, learner progress, assessments, grading, and certificates.
+- For Gameplan, preserve async discussion, decision, task, and workspace history.
+- For Drive, protect file permissions, sharing state, storage paths, previews, and linked records.
+- For HRMS, be careful with payroll, attendance, leave, claims, salary, and personal data.
+- For Insights, define metric grain, filters, permissions, freshness, and dashboard decision paths.
+- For Builder, optimize page UX, web forms, routing, SEO metadata, and content ownership.
+- For Payments, protect secrets, verify webhooks where possible, and keep payment/accounting flows idempotent.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-# Frappe Agent for Claude Code
+# Frappe Agent for Claude Code and AI Coding Workflows
 
-This repository contains Codex-native plugin assets plus portable Frappe/ERPNext development guidance.
+This repository contains Codex-native plugin assets plus portable Frappe, ERPNext, and Frappe ecosystem development guidance.
 
 When working in a Frappe or ERPNext codebase:
 
@@ -12,3 +12,5 @@ When working in a Frappe or ERPNext codebase:
 - Distinguish desk-native Vue and `frappe-ui` patterns from React or external SPA work.
 - When creating DocTypes, design the form UX deliberately with useful tabs, sections, and columns; include only fields that serve the actual use case.
 - Treat forked or custom-remote apps as custom-derived apps and be careful with upstream patching.
+- Route ecosystem work through the right app model: ERPNext, Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, or Payments.
+- Keep app-specific concerns explicit: tickets/SLA for Helpdesk, pipelines for CRM, enrollments for LMS, collaboration history for Gameplan, file permissions for Drive, payroll/privacy for HRMS, metric grain for Insights, SEO/content ownership for Builder, and secret-safe idempotent flows for Payments.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Frappe Agent for Codex
+# Frappe Agent
 
 [![HOL Trust Score](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dtrust%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
 [![HOL Security](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Ddhairya-marwaha%252Ffrappe-agent%26metric%3Dsecurity%26style%3Dflat)](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
 [![Release](https://img.shields.io/github/v/release/Dkm0315/frappe-agent)](https://github.com/Dkm0315/frappe-agent/releases)
 [![License](https://img.shields.io/github/license/Dkm0315/frappe-agent)](./LICENSE)
 
-`frappe-agent` is a Codex plugin for Frappe Framework and ERPNext development. It makes Codex more aware of Frappe-specific patterns so it can inspect benches more safely, choose the right customization layer, and avoid generic framework mistakes.
+`frappe-agent` is an AI coding assistant plugin for Frappe Framework, ERPNext, and the broader Frappe ecosystem. It gives Codex, Claude Code, Cursor, GitHub Copilot, and other assistant workflows Frappe-specific guidance for bench inspection, ERPNext customization, DocType design, SQL/ORM decisions, and ecosystem app development.
 
 ## About
 
-A Frappe and ERPNext agent plugin for Codex and Claude Code, with skills for backend, frontend, bench operations, SQL, customization, DocType design, and ERPNext workflows. Live plugin profile: [hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
+A Frappe and ERPNext agent plugin for AI coding tools, with skills for backend, frontend, bench operations, SQL, customization, DocType design, ERPNext modules, Frappe Helpdesk, Frappe CRM, Frappe LMS, Frappe Gameplan, Frappe Drive, Frappe HRMS, Frappe Insights, Frappe Builder, and Frappe Payments. Live plugin profile: [hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent](https://hol.org/registry/plugins/dhairya-marwaha%2Ffrappe-agent)
 
 ## What It Covers
 
@@ -18,7 +18,8 @@ A Frappe and ERPNext agent plugin for Codex and Claude Code, with skills for bac
 - Frappe-native SQL and ORM guidance
 - Customization-layer routing for `Custom Field`, `Property Setter`, `Client Script`, `Server Script`, `Workspace`, `Web Page`, `Report`, `Dashboard`, and related surfaces
 - DocType form UX guidance for useful fields, tabs, sections, columns, and required-field discipline
-- ERPNext-aware guidance for deciding between configuration, metadata, workflow, and code changes
+- ERPNext-aware guidance for accounting, selling, buying, stock, manufacturing, projects, HR, CRM, support, education, payments, and reporting
+- Ecosystem app guidance for Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, and Payments
 - Frontend guidance for Vue, React, `frappe-ui`, desk pages, `www`, and external SPA patterns
 
 ## Included Skills
@@ -32,6 +33,15 @@ A Frappe and ERPNext agent plugin for Codex and Claude Code, with skills for bac
 - `frappe-doctype-design`
 - `frappe-search`
 - `frappe-erpnext`
+- `frappe-helpdesk`
+- `frappe-crm`
+- `frappe-lms`
+- `frappe-gameplan`
+- `frappe-drive`
+- `frappe-hrms`
+- `frappe-insights`
+- `frappe-builder`
+- `frappe-payments`
 
 ## Installation
 
@@ -207,7 +217,7 @@ Each release uploads:
 
 ## Usage Examples
 
-Ask Codex to use the plugin naturally in the prompt:
+Ask a supported AI coding assistant to use the plugin naturally in the prompt:
 
 ```text
 Use Frappe Agent to inspect this bench before changing anything.
@@ -229,6 +239,18 @@ Use Frappe Agent to review whether this Frappe SQL should use frappe.db, frappe.
 Use Frappe Agent to decide whether this UI should be a desk page, a www page, a Vue frappe-ui page, or a React SPA.
 ```
 
+```text
+Use Frappe Agent to design a Helpdesk ticket workflow with SLA, assignment, portal, and reporting needs.
+```
+
+```text
+Use Frappe Agent to plan a Frappe CRM pipeline customization and decide what belongs in CRM versus ERPNext Selling.
+```
+
+```text
+Use Frappe Agent to improve SEO and form UX for a Frappe Builder landing page.
+```
+
 ## Repository Layout
 
 ```text
@@ -238,15 +260,7 @@ frappe-agent/
 │       └── marketplace.json
 ├── .cursor/
 │   ├── commands/
-│   │   ├── frappe-backend.md
-│   │   ├── frappe-bench.md
-│   │   ├── frappe-customization.md
-│   │   ├── frappe-doctype-design.md
-│   │   ├── frappe-erpnext.md
-│   │   ├── frappe-frontend.md
-│   │   ├── frappe-fullstack.md
-│   │   ├── frappe-search.md
-│   │   └── frappe-sql.md
+│   │   └── frappe-*.md
 │   └── rules/
 │       └── frappe-agent.mdc
 ├── .claude-plugin/
@@ -257,29 +271,14 @@ frappe-agent/
 ├── .github/
 │   ├── copilot-instructions.md
 │   └── workflows/
+│       ├── plugin-scan.yml
 │       └── release.yml
 ├── AGENTS.md
 ├── CLAUDE.md
 ├── commands/
-│   ├── frappe-backend.md
-│   ├── frappe-bench.md
-│   ├── frappe-customization.md
-│   ├── frappe-doctype-design.md
-│   ├── frappe-erpnext.md
-│   ├── frappe-frontend.md
-│   ├── frappe-fullstack.md
-│   ├── frappe-search.md
-│   └── frappe-sql.md
+│   └── frappe-*.md
 ├── skills/
-│   ├── frappe-backend/
-│   ├── frappe-bench/
-│   ├── frappe-customization/
-│   ├── frappe-doctype-design/
-│   ├── frappe-erpnext/
-│   ├── frappe-frontend/
-│   ├── frappe-fullstack/
-│   ├── frappe-search/
-│   └── frappe-sql/
+│   └── frappe-*/
 └── README.md
 ```
 
@@ -295,7 +294,6 @@ This repository is now:
 Planned future work:
 
 - official Claude marketplace submission
-- richer Cursor command bundles
 - deeper Copilot instruction coverage
 
 ## Design Goals
@@ -308,9 +306,9 @@ Planned future work:
 
 ## Roadmap
 
-- Add more first-class skills for custom fields, reports, workflows, dashboards, and upgrade planning
+- Add more first-class skills for custom fields, reports, workflows, dashboards, upgrade planning, and additional Frappe ecosystem apps
 - Add better source-backed command and flag coverage for Bench
-- Add distribution adapters for Claude Code, Cursor, and Copilot
+- Add deeper distribution adapters for Claude Code, Cursor, and Copilot
 - Add richer repo examples and team onboarding docs
 
 ## License

--- a/commands/frappe-builder.md
+++ b/commands/frappe-builder.md
@@ -1,0 +1,8 @@
+# Frappe Builder
+
+Handle the task as Frappe Builder or Frappe website work.
+
+- Identify page purpose, audience, conversion goal, content owner, forms, routing, SEO, analytics, and publishing needs.
+- Prefer Builder pages, blocks, web forms, website settings, redirects, scripts, styles, and metadata before custom frontend code.
+- Keep content, layout, forms, business logic, and integrations separate.
+- Include clear title, description, readable headings, internal links, and useful content.

--- a/commands/frappe-crm.md
+++ b/commands/frappe-crm.md
@@ -1,0 +1,8 @@
+# Frappe CRM
+
+Handle the task as Frappe CRM work.
+
+- Identify leads, deals, contacts, organizations, activities, pipelines, and ownership rules.
+- Prefer pipeline configuration, custom fields, workflows, notifications, reports, dashboards, and workspaces before code.
+- Be deliberate about integration with ERPNext Selling records.
+- Keep owner, stage, value, probability, next follow-up, last activity, and blockers visible.

--- a/commands/frappe-drive.md
+++ b/commands/frappe-drive.md
@@ -1,0 +1,8 @@
+# Frappe Drive
+
+Handle the task as Frappe Drive work.
+
+- Identify file/folder ownership, sharing, visibility, storage, previews, indexing, retention, and linked records.
+- Prefer roles, sharing rules, custom fields, workflows, reports, dashboards, and built-in attachment APIs before custom storage logic.
+- Preserve file permission checks and avoid exposing private paths or signed URLs too broadly.
+- Keep file name, type, owner, location, sharing state, linked record, recent activity, and primary actions visible.

--- a/commands/frappe-gameplan.md
+++ b/commands/frappe-gameplan.md
@@ -1,0 +1,8 @@
+# Frappe Gameplan
+
+Handle the task as Frappe Gameplan work.
+
+- Identify projects, tasks, discussions, decisions, notes, milestones, teams, and visibility rules.
+- Prefer workspace setup, permissions, custom fields, workflows, notifications, reports, dashboards, and integrations before code.
+- Preserve async collaboration history and decision trails.
+- Make ownership, due dates, blockers, recent decisions, and pending activity easy to scan.

--- a/commands/frappe-helpdesk.md
+++ b/commands/frappe-helpdesk.md
@@ -1,0 +1,8 @@
+# Frappe Helpdesk
+
+Handle the task as Frappe Helpdesk work.
+
+- Identify ticket lifecycle, channels, SLA, priority, escalation, and assignment needs.
+- Prefer Helpdesk settings, custom fields, workflows, notifications, reports, dashboards, and portal configuration before app code.
+- Preserve customer, agent, team, and guest permission boundaries.
+- Make status, priority, requester, assignee, SLA state, latest response, and next action easy to scan.

--- a/commands/frappe-hrms.md
+++ b/commands/frappe-hrms.md
@@ -1,0 +1,8 @@
+# Frappe HRMS
+
+Handle the task as Frappe HRMS work.
+
+- Identify attendance, leave, payroll, shifts, claims, recruitment, onboarding, appraisals, and HR reports.
+- Prefer HR settings, leave types, holiday lists, shifts, salary components, workflows, custom fields, reports, dashboards, and notifications before code.
+- Protect salary, personal, attendance, and performance data.
+- Call out jurisdiction-specific payroll assumptions.

--- a/commands/frappe-insights.md
+++ b/commands/frappe-insights.md
@@ -1,0 +1,8 @@
+# Frappe Insights
+
+Handle the task as Frappe Insights and analytics work.
+
+- Define the business question, metric grain, filters, audience, freshness, and permissions.
+- Choose between Frappe Insights, ERPNext reports, Query Reports, Script Reports, Dashboards, and Workspaces.
+- Prefer permission-aware APIs and Query Builder before raw SQL.
+- Define numerator, denominator, date basis, status filters, units, and exclusions.

--- a/commands/frappe-lms.md
+++ b/commands/frappe-lms.md
@@ -1,0 +1,8 @@
+# Frappe LMS
+
+Handle the task as Frappe LMS work.
+
+- Identify learner, instructor, evaluator, and admin roles.
+- Separate course, batch, lesson, quiz, assignment, assessment, enrollment, progress, and certificate concerns.
+- Prefer LMS configuration, custom fields, workflows, web forms, notifications, reports, dashboards, and certificate templates before code.
+- Protect learner data, grading, enrollment, and assessment permissions.

--- a/commands/frappe-payments.md
+++ b/commands/frappe-payments.md
@@ -1,0 +1,8 @@
+# Frappe Payments
+
+Handle the task as Frappe Payments or ERPNext payment workflow work.
+
+- Identify gateway, currency, customer, invoice/order, subscription, settlement, refund, and reconciliation flows.
+- Prefer gateway settings, Payment Request, Payment Entry, Sales Invoice, notifications, webhooks, reports, and dashboards before custom transaction records.
+- Never hardcode gateway secrets or expose credentials in client code.
+- Make webhook handlers idempotent and verify signatures where supported.

--- a/skills/frappe-builder/SKILL.md
+++ b/skills/frappe-builder/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frappe-builder
+description: Frappe Builder website and page-building guidance for pages, blocks, components, forms, routing, CMS-style content, SEO, and web UX. Use when work touches Frappe Builder, website pages, landing pages, or content-driven experiences.
+---
+
+Act as a Frappe Builder and website UX specialist.
+
+First identify:
+- page purpose, audience, conversion goal, and content owner
+- whether the surface is Frappe Builder, Website/Web Page, portal, `www`, Vue, React, or an external frontend
+- forms, routing, SEO, metadata, analytics, and content publishing requirements
+
+Prefer Builder and website configuration when suitable:
+- pages, blocks, reusable sections, web forms, website settings, redirects, scripts, styles, and metadata
+- custom frontend code only when Builder or standard website pages cannot support the interaction
+
+When implementing:
+- keep content, layout, forms, business logic, and integrations separate
+- ensure generated forms validate server-side and respect permissions
+- include SEO essentials: clear title, description, canonical intent, readable headings, internal links, and useful content
+
+For UX, build pages around the user's task or decision, not decorative blocks. Keep primary action, proof, details, and next steps visible and responsive.

--- a/skills/frappe-crm/SKILL.md
+++ b/skills/frappe-crm/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: frappe-crm
+description: Frappe CRM guidance for leads, deals, contacts, organizations, pipelines, activities, assignment, dashboards, and sales workflows. Use when work touches Frappe CRM or CRM-style sales processes in the Frappe ecosystem.
+---
+
+Act as a Frappe CRM specialist.
+
+First determine:
+- whether the business object is a lead, deal, contact, organization, activity, note, or custom sales object
+- pipeline stages, ownership, assignment, and follow-up rules
+- whether ERPNext Selling integration is required or the CRM app should remain the source of truth
+- whether the request is configuration, metadata, workflow, report/dashboard, frontend, or code
+
+Prefer built-in and metadata-driven changes:
+- pipeline/stage configuration, custom fields, list/form layout, workflows, notifications, reports, dashboards, and workspaces
+- clean linking to Customer, Opportunity, Quotation, Sales Order, or Contact only when that handoff is part of the process
+
+When adding features:
+- keep lead qualification, deal progression, activity logging, and account/contact data distinct
+- protect visibility and assignment rules so users do not see unrelated pipelines or teams
+- avoid duplicating ERPNext selling data unless a deliberate sync boundary is defined
+
+For forms and dashboards, optimize for sales action: owner, stage, value, probability, next follow-up, last activity, and blockers should be easy to scan.

--- a/skills/frappe-drive/SKILL.md
+++ b/skills/frappe-drive/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: frappe-drive
+description: Frappe Drive guidance for files, folders, sharing, permissions, storage, previews, document workflows, and file-linked business processes. Use when work touches Frappe Drive or file management in the Frappe ecosystem.
+---
+
+Act as a Frappe Drive specialist.
+
+Start by identifying:
+- file/folder ownership, sharing model, and visibility boundary
+- whether files are standalone knowledge assets or attached to ERPNext/Frappe records
+- storage, preview, indexing, retention, and audit requirements
+- whether the change belongs in configuration, metadata, permissions, frontend, or storage/backend code
+
+Prefer standard surfaces first:
+- roles, sharing rules, custom fields, workflows, reports, dashboards, and record attachments
+- built-in file APIs and attachment behavior before custom storage logic
+
+When code is needed:
+- preserve file permission checks and avoid exposing private paths or signed URLs too broadly
+- keep storage, metadata, preview, sharing, and indexing concerns separate
+- plan migrations carefully when moving or transforming stored files
+
+For UX, prioritize file name, type, owner, location, sharing state, linked record, recent activity, and primary actions.

--- a/skills/frappe-erpnext/SKILL.md
+++ b/skills/frappe-erpnext/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: frappe-erpnext
-description: ERPNext-aware reasoning for module customization, workflows, reports, dashboards, workspaces, and choosing between configuration, metadata, and code changes. Use when a task affects ERPNext module behavior.
+description: ERPNext-aware reasoning for accounting, selling, buying, stock, manufacturing, projects, HR, support, education, CRM, and other ERPNext module work. Use when a task affects ERPNext module behavior, configuration, reports, dashboards, workflows, or customizations.
 ---
 
 Act as an ERPNext customization advisor for developers.
@@ -11,12 +11,24 @@ Help the user determine:
 - whether a change belongs in ERPNext settings, builder DocTypes, a custom app, or a custom-derived app
 
 Cover common domains broadly:
-- manufacturing
-- buying
-- selling
-- CRM
-- HR
-- accounts and reporting
-- customer-facing website or portal flows
+- Accounting, payments, taxes, reports, dashboards, and financial controls
+- Selling, CRM, quotations, orders, pricing, subscriptions, and customer portals
+- Buying, suppliers, purchase orders, procurement, and approvals
+- Stock, warehouses, batches, serial numbers, valuation, and fulfilment
+- Manufacturing, BOMs, work orders, job cards, quality, and capacity
+- Projects, tasks, timesheets, support, service, and delivery operations
+- HR, payroll, attendance, leave, shifts, claims, and recruitment
+- Education, LMS, website, portal, content, and customer-facing flows
 
 Prefer showing the safest customization layer before proposing invasive code changes.
+
+When a task maps to a richer ecosystem app, route into the matching companion skill:
+- `frappe-crm`
+- `frappe-helpdesk`
+- `frappe-lms`
+- `frappe-gameplan`
+- `frappe-drive`
+- `frappe-hrms`
+- `frappe-insights`
+- `frappe-builder`
+- `frappe-payments`

--- a/skills/frappe-fullstack/SKILL.md
+++ b/skills/frappe-fullstack/SKILL.md
@@ -27,6 +27,15 @@ When relevant, route into these companion skills:
 - `frappe-doctype-design`
 - `frappe-search`
 - `frappe-erpnext`
+- `frappe-crm`
+- `frappe-helpdesk`
+- `frappe-lms`
+- `frappe-gameplan`
+- `frappe-drive`
+- `frappe-hrms`
+- `frappe-insights`
+- `frappe-builder`
+- `frappe-payments`
 
 Be opinionated about:
 - not restarting an already running bench

--- a/skills/frappe-gameplan/SKILL.md
+++ b/skills/frappe-gameplan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frappe-gameplan
+description: Frappe Gameplan guidance for team discussions, projects, tasks, notes, decisions, async collaboration, permissions, and workspace workflows. Use when work touches Gameplan or planning/collaboration features in the Frappe ecosystem.
+---
+
+Act as a Frappe Gameplan specialist.
+
+First clarify:
+- whether the object is a project, task, discussion, decision, note, milestone, or team workspace
+- team membership, visibility, ownership, and notification needs
+- whether the process is lightweight collaboration or needs formal ERPNext project/accounting integration
+
+Prefer configuration and metadata before code:
+- workspace setup, permissions, custom fields, status/workflow metadata, notifications, reports, dashboards, and integrations
+- links to ERPNext Project, Task, Issue, or Timesheet only when the operating process needs those records
+
+When implementing:
+- keep discussion, task state, decisions, and project delivery data separate
+- preserve async collaboration history and avoid destructive edits to comments, decisions, or audit trails
+- be careful with cross-team visibility and private workspaces
+
+For UX, make ownership, due dates, blockers, recent decisions, and unread or pending activity easy to scan.

--- a/skills/frappe-helpdesk/SKILL.md
+++ b/skills/frappe-helpdesk/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: frappe-helpdesk
+description: Frappe Helpdesk implementation and customization guidance for ticket intake, SLAs, assignment, portals, knowledge base, notifications, and support workflows. Use when work touches the Frappe Helpdesk app or customer support operations.
+---
+
+Act as a Frappe Helpdesk specialist.
+
+Start by identifying:
+- ticket lifecycle and status model
+- support channels such as email, portal, chat, or manual intake
+- SLA, priority, escalation, and assignment rules
+- whether the change belongs in Helpdesk settings, workflows, notifications, custom fields, reports, or app code
+
+Prefer configuration and metadata first:
+- teams, agents, assignment rules, priorities, ticket types, and SLA policies
+- `Custom Field`, `Property Setter`, `Workflow`, `Notification`, `Email Account`, `Email Template`, `Report`, and `Dashboard`
+- portal and knowledge-base configuration before custom frontend work
+
+When code is needed:
+- keep ticket controller, assignment, notification, and portal logic separate
+- preserve permission boundaries between agents, customers, contacts, and guests
+- avoid bypassing Helpdesk's standard status, SLA, and communication trail unless the business process truly requires it
+
+For UX changes, make support flows fast to scan: status, priority, requester, assignee, SLA state, latest response, and next action should be visible before secondary metadata.

--- a/skills/frappe-hrms/SKILL.md
+++ b/skills/frappe-hrms/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frappe-hrms
+description: Frappe HRMS and ERPNext HR guidance for employees, attendance, leave, payroll, shifts, expense claims, recruitment, onboarding, and HR workflows. Use when work touches HRMS or people operations in the Frappe ecosystem.
+---
+
+Act as a Frappe HRMS specialist.
+
+First determine:
+- employee, contractor, applicant, manager, HR user, and payroll role boundaries
+- whether the request touches attendance, leave, payroll, shifts, claims, recruitment, onboarding, appraisals, or reports
+- whether the safest path is settings, metadata, workflow, salary structures, reports, or code
+
+Prefer configuration and metadata:
+- HR settings, leave types, holiday lists, shifts, salary components, workflows, custom fields, reports, dashboards, and notifications
+- statutory and payroll-sensitive behavior should use standard HRMS features where possible
+
+When implementing:
+- protect salary, personal, attendance, and performance data with strict permissions
+- keep payroll calculations, attendance ingestion, leave allocation, and approval workflow concerns separate
+- avoid localizing payroll logic casually; call out jurisdiction-specific assumptions
+
+For forms and reports, foreground employee, period, status, approver, financial impact, and exceptions that need action.

--- a/skills/frappe-insights/SKILL.md
+++ b/skills/frappe-insights/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: frappe-insights
+description: Frappe Insights and analytics guidance for dashboards, query design, charts, permissions, metrics, ERPNext reporting, and operational analytics. Use when work touches Frappe Insights or analytics in the Frappe ecosystem.
+---
+
+Act as a Frappe Insights and analytics specialist.
+
+Start by identifying:
+- the business question, metric definitions, grain, filters, and target audience
+- whether the answer belongs in Frappe Insights, ERPNext Report, Query Report, Script Report, Dashboard, or Workspace
+- data source, permissions, freshness, and performance constraints
+
+Prefer safe analytical paths:
+- standard reports and dashboards before custom SQL
+- Query Builder or permission-aware APIs when possible
+- raw SQL only when the metric requires it and permission implications are understood
+
+When building analytics:
+- define numerator, denominator, date basis, status filters, currency/unit, and exclusions
+- avoid mixing operational and accounting grains without explicit joins and reconciliation notes
+- keep query performance and row-level visibility in mind
+
+For dashboards, prioritize a small set of actionable metrics, clear filters, drill-down paths, and charts that match the decision being made.

--- a/skills/frappe-lms/SKILL.md
+++ b/skills/frappe-lms/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: frappe-lms
+description: Frappe LMS customization guidance for courses, batches, lessons, quizzes, assessments, enrollment, progress, certificates, portals, and learning workflows. Use when work touches Frappe LMS or education/training flows.
+---
+
+Act as a Frappe LMS specialist.
+
+Start by identifying:
+- learner, instructor, evaluator, and administrator roles
+- course, batch, lesson, quiz, assignment, assessment, and certificate lifecycle
+- enrollment, progress tracking, grading, completion, and notification requirements
+- whether the change is configuration, metadata, portal UX, reports, or code
+
+Prefer standard LMS surfaces first:
+- course/batch configuration, custom fields, workflows, web forms, notifications, reports, dashboards, and certificate templates
+- portal and website customization before building a separate app
+
+When code is required:
+- preserve enrollment and permission checks for learners and instructors
+- keep progress, grading, certificate issuance, and content publishing concerns separate
+- avoid storing assessment answers or private learner data in weakly protected custom fields
+
+Design learning UX around next action: continue learning, pending assessment, instructor feedback, progress, deadline, and certificate state should be obvious.

--- a/skills/frappe-payments/SKILL.md
+++ b/skills/frappe-payments/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: frappe-payments
+description: Frappe Payments and ERPNext payment workflow guidance for payment gateways, payment requests, subscriptions, invoices, reconciliation, webhooks, and secure checkout flows. Use when work touches payments in Frappe or ERPNext.
+---
+
+Act as a Frappe Payments specialist.
+
+Start by identifying:
+- payment gateway, currency, customer, invoice/order, subscription, and settlement flow
+- whether the request touches Payment Request, Sales Invoice, Payment Entry, payment gateway settings, webhook handling, or portal checkout
+- compliance, secret handling, reconciliation, refund, and failure-state requirements
+
+Prefer standard payment surfaces first:
+- gateway settings, Payment Request, Payment Entry, Sales Invoice, notifications, webhooks, reports, and dashboards
+- ERPNext accounting flows before custom transaction records
+
+When code is required:
+- never hardcode gateway secrets or expose credentials in client code
+- verify webhook signatures where supported and make handlers idempotent
+- keep checkout, gateway communication, accounting posting, reconciliation, and notifications separate
+
+For UX, make payment status, amount, currency, gateway reference, invoice/order link, failure reason, and retry/refund actions clear.


### PR DESCRIPTION
## Summary
- broaden README and plugin metadata from Codex-only framing to AI coding assistant support across Codex, Claude Code, Cursor, Copilot, and portable workflows
- add ecosystem-specific skills for Frappe Helpdesk, CRM, LMS, Gameplan, Drive, HRMS, Insights, Builder, and Payments
- add matching Claude command files and Cursor command files for the new ecosystem modules
- expand ERPNext/fullstack routing guidance and portable AGENTS/CLAUDE/Copilot instructions
- update README SEO language around Frappe Framework, ERPNext, and Frappe ecosystem apps

## GitHub repo discovery notes
Current GitHub network data shows 2 forks:
- `ajay374-J/frappe-agent` created 2026-05-11
- `Snovel993/frappe-agent` created 2026-06-21

The repository About metadata was also updated with broader Frappe ecosystem wording and additional topics for Helpdesk, CRM, LMS, Drive, HRMS, Builder, and AI coding discovery.

## Validation
- `python3 -m json.tool .codex-plugin/plugin.json`
- `python3 -m json.tool .agents/plugins/marketplace.json`
- `python3 -m json.tool .claude-plugin/plugin.json`
- `python3 -m json.tool .claude-plugin/marketplace.json`
- validated frontmatter for all 18 `skills/*/SKILL.md` files
- `pipx run --spec 'plugin-scanner' plugin-scanner scan . --format text` reported `Final Score: 98/100` with no critical/high/medium/low findings
