### PR TITLE
Fix Codex marketplace compatibility

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -7,11 +7,12 @@
     {
       "name": "frappe-agent",
       "source": {
+        "source": "local",
         "path": "./"
       },
       "policy": {
         "installation": "AVAILABLE",
-        "authentication": "ON_FIRST_USE"
+        "authentication": "ON_USE"
       },
       "category": "Developer Tools"
     }


### PR DESCRIPTION
## What changed

- declare the marketplace plugin source as local
- replace the unsupported `ON_FIRST_USE` authentication policy with `ON_USE`

## Why

Codex CLI 0.144.5 rejects `ON_FIRST_USE` because the current marketplace schema only accepts `ON_INSTALL` or `ON_USE`. Without the explicit local source discriminator, the marketplace can be registered but the plugin is not discoverable.

## Impact

The repository can be added as a local Codex marketplace, and `frappe-agent` can then be installed and enabled normally.

## Validation

- `codex plugin marketplace add /Users/grawish/frappe-agent --json`
- `codex plugin add frappe-agent@frappe-agent --json`
- verified `frappe-agent@frappe-agent` reports `installed, enabled` at version `0.1.0`
- verified all eight bundled Frappe skills were installed
